### PR TITLE
Rename travis.yml to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ python:
 
 # command to install dependencies
 install:
-  - pip install .
   - pip install -r requirements.txt
 
 # command to run tests


### PR DESCRIPTION
Travis requires the configuration file to be named [.travis.yml][travis-getting-started]. 

[travis-getting-started]: https://docs.travis-ci.com/user/getting-started/